### PR TITLE
Add doc comment for note_commitment

### DIFF
--- a/app.zk_rollup.nr
+++ b/app.zk_rollup.nr
@@ -15,6 +15,7 @@ struct Note {
     blinding: Field,
 }
 
+/// Commitment scheme used for notes: Pedersen(value, blinding).
 fn note_commitment(note: Note) -> Field {
     let inputs: [Field; 2] = [note.value as Field, note.blinding];
     pedersen(inputs)


### PR DESCRIPTION
Make the commitment scheme explicit for anyone reading the circuit or re-implementing off-chain.