### PR TITLE
Explicit check that no value is created: old ≥ new

### DIFF
--- a/app.zk_rollup.nr
+++ b/app.zk_rollup.nr
@@ -54,6 +54,8 @@ fn main(
     // Value conservation: old_value = new_value + fee
     // No hidden value creation inside this rollup step.
     assert(old_value == new_value + fee);
+    // Explicit check: cannot create value (old_value must be >= new_value).
+    assert(old_value >= new_value);
 
     // Basic sanity checks
     assert(old_value > 0);


### PR DESCRIPTION
This is implied by old_value == new_value + fee, but an explicit inequality makes the intent more obvious and a bit more robust if you ever tweak the equation later.