### PR TITLE
Ensure commitments are not trivially zero

### DIFF
--- a/app.zk_rollup.nr
+++ b/app.zk_rollup.nr
@@ -26,6 +26,10 @@ fn main(
     public new_commitment: Field,
     public fee: u64,
 
+    // Disallow trivial zero commitments on-chain.
+    assert(old_commitment != 0);
+    assert(new_commitment != 0);
+
     // private witness for old note
     old_value: u64,
     old_blinding: Field,


### PR DESCRIPTION
Depending on the Pedersen implementation, the all-zero input might map to a special point. It can be nice to disallow zero commitments at the circuit level.