### PR TITLE
Add an invariant that new note is strictly positive after fee

### DIFF
--- a/app.zk_rollup.nr
+++ b/app.zk_rollup.nr
@@ -60,3 +60,6 @@ fn main(
     assert(new_value > 0);
     assert(fee <= old_value);
 }
+    // Policy: output note must retain some value after paying the fee.
+    assert(new_value + fee >= new_value); // cheap overflow sanity
+


### PR DESCRIPTION
require new_value > 0, but you can emphasise that the fee cannot eat the entire note (if that’s a policy you want).