### PR TITLE
Refactor: simplify `note_commitment` function for readability

### DIFF
--- a/simple_transfer.nr
+++ b/simple_transfer.nr
@@ -20,6 +20,14 @@ fn note_commitment(note: Note) -> Field {
     ];
     pedersen::hash_many([limbs[0], limbs[1], limbs[2], limbs[3], note.blinding])
 }
+// Rename `limbs` to `value_parts` for clarity
+let value_parts = [
+    (note.value & 0xFFFF) as u16,
+    ((note.value >> 16) & 0xFFFF) as u16,
+    ((note.value >> 32) & 0xFFFF) as u16,
+    ((note.value >> 48) & 0xFFFF) as u16,
+];
+pedersen::hash_many([value_parts[0], value_parts[1], value_parts[2], value_parts[3], note.blinding])
 
 fn main(
     // Public inputs


### PR DESCRIPTION
## Summary

The `note_commitment` function currently packs the `u64` value into multiple `u16` values before hashing. This can be made more readable by using clearer variable names and reducing complexity.

## Proposed Changes

- Rename the `limbs` array to something more descriptive, e.g., `value_parts`.
- Simplify how the value is split into 4 parts for clarity.

## Motivation

- Makes the code easier to understand and maintain.
- Improves readability for new contributors and reviewers.